### PR TITLE
Add path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Then, set up this Action as a step in your Actions workflow, e.g. for a typical 
 * `java_distribution`: The Java distribution to use. Default: `microsoft`
 * `java_version`: The Java version to use. Default: `11`
 * `no_cache`: Do not use cached versions of the Spotbugs and FindSecBugs tools. Default: `false`
+* `path_prefix`: Add this path prefix to the start of file locations. Required: `false`
 
 ## Full sample workflow
 
@@ -39,6 +40,9 @@ A: Several SpotBugs plugins are usable in CI/CD and Actions, but don't output SA
 
 Q: Why doesn't the Action support setting argument X of SpotBugs?
 A: It's a work-in-progress. Please raise an issue or a PR if you need a feature.
+
+Q: Why do the files not resolve in the Code Scanning results?
+A: The paths in the Jar or Class file metadata might not match up with the root of the repository. Try using the input `path_prefix`. If two build targets don't share the same prefix, then try running this Action twice, once per target with a different prefix for each.
 
 ## Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
     required: false
     type: boolean
     default: 'false'
+  path_prefix:
+    description: 'Add this path prefix to the start of file locations'
+    required: false
 
 runs:
   using: "composite"
@@ -99,6 +102,15 @@ runs:
       run: |
         SPOTBUGS_FILES=$(find "${INPUT_SPOTBUGS_TARGET}" -type f -name "${INPUT_SPOTBUGS_GLOB}" -exec echo -n {} \+)
         "${SPOTBUGS_HOME}/bin/spotbugs" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
+      shell: bash
+    - name: Adjust file paths
+      if: inputs.path_prefix != null
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+      run: |
+        jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation | $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
+        mv spotbugs.sarf spotbugs_orig.sarif
+        mv spotbugs_edited.sarif spotbugs.sarif
       shell: bash
     - name: Upload SARIF file
       if: inputs.upload_sarif == 'true'

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
         SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
         cd "${SPOTBUGS_WORKING}"
-        jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation | $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
+        jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation |= $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
         mv spotbugs.sarif spotbugs_orig.sarif
         mv spotbugs_edited.sarif spotbugs.sarif
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
         SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
         cd "${SPOTBUGS_WORKING}"
-        jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation |= $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
+        jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation.uri |= $prefix + .' < spotbugs.sarif > spotbugs_edited.sarif
         mv spotbugs.sarif spotbugs_orig.sarif
         mv spotbugs_edited.sarif spotbugs.sarif
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -118,8 +118,6 @@ runs:
       shell: bash
     - name: Upload SARIF file
       if: inputs.upload_sarif == 'true'
-      env:
-        SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       uses: github/codeql-action/upload-sarif@v2
       with:
-        sarif_file: "${SPOTBUGS_WORKING}"/spotbugs.sarif
+        sarif_file: /home/runner/work/spotbugs_working+/spotbugs.sarif

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,9 @@ runs:
         INPUT_SPOTBUGS_GLOB: ${{ inputs.spotbugs_filename_glob }}
         SPOTBUGS_HOME: /home/runner/work/spotbugs+/spotbugs-${{ inputs.spotbugs_version }}
         FINDSECBUGS_HOME: /home/runner/work/findsecbugs+/
+        SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
+        cd "${SPOTBUGS_WORKING}"
         SPOTBUGS_FILES=$(find "${INPUT_SPOTBUGS_TARGET}" -type f -name "${INPUT_SPOTBUGS_GLOB}" -exec echo -n {} \+)
         "${SPOTBUGS_HOME}/bin/spotbugs" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
       shell: bash
@@ -107,13 +109,17 @@ runs:
       if: inputs.path_prefix != null
       env:
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
+        cd "${SPOTBUGS_WORKING}"
         jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation | $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
-        mv spotbugs.sarf spotbugs_orig.sarif
+        mv spotbugs.sarif spotbugs_orig.sarif
         mv spotbugs_edited.sarif spotbugs.sarif
       shell: bash
     - name: Upload SARIF file
       if: inputs.upload_sarif == 'true'
+      env:
+        SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       uses: github/codeql-action/upload-sarif@v2
       with:
-        sarif_file: spotbugs.sarif
+        sarif_file: "${SPOTBUGS_WORKING}"/spotbugs.sarif

--- a/action.yml
+++ b/action.yml
@@ -84,10 +84,10 @@ runs:
       if: inputs.no_cache == 'true' || steps.cache-findsecbugs.outputs.cache-hit != 'true'
       env:
         INPUT_FINDSECBUGS_VERSION: ${{ inputs.findsecbugs_version }}
+        FINDSECBUGS_HOME: /home/runner/work/findsecbugs+/
       run: |
-        cd /home/runner/work/
-        mkdir -p 'findsecbugs+'
-        cd 'findsecbugs+'
+        mkdir -p "${FINDSECBUGS_HOME}"
+        cd "${FINDSECBUGS_HOME}"
         wget -q -O "findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" "https://search.maven.org/remotecontent?filepath=com/h3xstream/findsecbugs/findsecbugs-plugin/${INPUT_FINDSECBUGS_VERSION}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar"
         ls "findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar"
         echo "Got findsecbugs"
@@ -101,6 +101,7 @@ runs:
         FINDSECBUGS_HOME: /home/runner/work/findsecbugs+/
         SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
+        mkdir -p "${SPOTBUGS_WORKING}"
         cd "${SPOTBUGS_WORKING}"
         SPOTBUGS_FILES=$(find "${INPUT_SPOTBUGS_TARGET}" -type f -name "${INPUT_SPOTBUGS_GLOB}" -exec echo -n {} \+)
         "${SPOTBUGS_HOME}/bin/spotbugs" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
@@ -111,6 +112,7 @@ runs:
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
         SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
+        mkdir -p "${SPOTBUGS_WORKING}"
         cd "${SPOTBUGS_WORKING}"
         jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation | $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
         mv spotbugs.sarif spotbugs_orig.sarif

--- a/action.yml
+++ b/action.yml
@@ -70,10 +70,10 @@ runs:
       if: inputs.no_cache == 'true' || steps.cache-spotbugs.outputs.cache-hit != 'true'
       env:
         INPUT_SPOTBUGS_VERSION: ${{ inputs.spotbugs_version }}
+        SPOTBUGS_HOME: /home/runner/work/spotbugs+/
       run: |
-        cd /home/runner/work/
-        mkdir -p 'spotbugs+'
-        cd 'spotbugs+'
+        mkdir -p "${SPOTBUGS_HOME}"
+        cd "${SPOTBUGS_HOME}"
         wget -q -O spotbugs-"${INPUT_SPOTBUGS_VERSION}".tgz "https://github.com/spotbugs/spotbugs/releases/download/${INPUT_SPOTBUGS_VERSION}/spotbugs-${INPUT_SPOTBUGS_VERSION}.tgz"
         tar -xzf spotbugs-"${INPUT_SPOTBUGS_VERSION}".tgz
         chmod +x spotbugs-"${INPUT_SPOTBUGS_VERSION}"/bin/spotbugs
@@ -103,7 +103,7 @@ runs:
       run: |
         mkdir -p "${SPOTBUGS_WORKING}"
         cd "${SPOTBUGS_WORKING}"
-        SPOTBUGS_FILES=$(find "${INPUT_SPOTBUGS_TARGET}" -type f -name "${INPUT_SPOTBUGS_GLOB}" -exec echo -n {} \+)
+        SPOTBUGS_FILES=$(find "${GITHUB_WORKSPACE}/${INPUT_SPOTBUGS_TARGET}" -type f -name "${INPUT_SPOTBUGS_GLOB}" -exec echo -n {} \+)
         "${SPOTBUGS_HOME}/bin/spotbugs" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
       shell: bash
     - name: Adjust file paths
@@ -112,7 +112,6 @@ runs:
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
         SPOTBUGS_WORKING: /home/runner/work/spotbugs_working+/
       run: |
-        mkdir -p "${SPOTBUGS_WORKING}"
         cd "${SPOTBUGS_WORKING}"
         jq --arg prefix "${INPUT_PATH_PREFIX}" '.runs[].results[].locations[].physicalLocation.artifactLocation | $prefix + .uri' < spotbugs.sarif > spotbugs_edited.sarif
         mv spotbugs.sarif spotbugs_orig.sarif


### PR DESCRIPTION
Add the ability to set a path prefix to file locations in the SARIF.

Useful for when a paths in a Jar are relative to a different directory than the root of the repository.