### PR TITLE
ci: explicit set GITHUB_TOKEN permissions

### DIFF
--- a/starter-workflow.yml
+++ b/starter-workflow.yml
@@ -13,6 +13,11 @@ on:
 jobs:
     spotbugs:
       runs-on: ubuntu-latest
+      permissions:
+        actions: read
+        contents: read
+        security-events: write
+        
       steps:
         - name: Checkout
           uses: actions/checkout@v3


### PR DESCRIPTION
If the `GITHUB_TOKEN` default permissions is set to [restrictive](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), the `security-events` will be read-only.
This prevents all write operations such as SARIF upload actions.

We cannot rely on all users of this actions to set their [default `GITHUB_TOKEN` permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions) to be permissive so better set the job's permissions explicitly.

It also sets clear expectations about the actual permission level required to run this action.