### PR TITLE
Add RAM input to Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
         INPUT_FINDSECBUGS_VERSION: ${{ inputs.findsecbugs_version }}
         INPUT_SPOTBUGS_TARGET: ${{ inputs.spotbugs_target }}
         INPUT_SPOTBUGS_GLOB: ${{ inputs.spotbugs_filename_glob }}
-        INPUT_RAM: {{ inputs.ram }}
+        INPUT_RAM: ${{ inputs.ram }}
         SPOTBUGS_HOME: ${{ inputs.base_path }}/spotbugs+/spotbugs-${{ inputs.spotbugs_version }}
         FINDSECBUGS_HOME: ${{ inputs.base_path }}/findsecbugs+/
         SPOTBUGS_WORKING: ${{ inputs.base_path }}/spotbugs_working+/
@@ -119,7 +119,7 @@ runs:
         "${SPOTBUGS_HOME}/bin/spotbugs" -maxHeap "${INPUT_RAM}" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
       shell: bash
     - name: Adjust file paths
-      if: inputs.path_prefix != ""
+      if: inputs.path_prefix != ''
       env:
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
         SPOTBUGS_WORKING: ${{ inputs.base_path }}/spotbugs_working+/

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
   path_prefix:
     description: 'Add this path prefix to the start of file locations'
     required: false
+  ram:
+    description: 'The amount of RAM to use for SpotBugs (in MB)'
+    required: false
+    default: '768'
 
   # Allows for a custom runner home directory to be specified for self-hosted runners
   base_path:
@@ -104,6 +108,7 @@ runs:
         INPUT_FINDSECBUGS_VERSION: ${{ inputs.findsecbugs_version }}
         INPUT_SPOTBUGS_TARGET: ${{ inputs.spotbugs_target }}
         INPUT_SPOTBUGS_GLOB: ${{ inputs.spotbugs_filename_glob }}
+        INPUT_RAM: {{ inputs.ram }}
         SPOTBUGS_HOME: ${{ inputs.base_path }}/spotbugs+/spotbugs-${{ inputs.spotbugs_version }}
         FINDSECBUGS_HOME: ${{ inputs.base_path }}/findsecbugs+/
         SPOTBUGS_WORKING: ${{ inputs.base_path }}/spotbugs_working+/
@@ -111,10 +116,10 @@ runs:
         mkdir -p "${SPOTBUGS_WORKING}"
         cd "${SPOTBUGS_WORKING}"
         SPOTBUGS_FILES=$(find "${GITHUB_WORKSPACE}/${INPUT_SPOTBUGS_TARGET}" -type f -name "${INPUT_SPOTBUGS_GLOB}" -exec echo -n {} \+)
-        "${SPOTBUGS_HOME}/bin/spotbugs" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
+        "${SPOTBUGS_HOME}/bin/spotbugs" -maxHeap "${INPUT_RAM}" -textui -quiet -effort:max -low -bugCategories SECURITY -pluginList "${FINDSECBUGS_HOME}/findsecbugs-plugin-${INPUT_FINDSECBUGS_VERSION}.jar" -sarif=spotbugs.sarif ${SPOTBUGS_FILES}
       shell: bash
     - name: Adjust file paths
-      if: inputs.path_prefix != null
+      if: inputs.path_prefix != ""
       env:
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
         SPOTBUGS_WORKING: ${{ inputs.base_path }}/spotbugs_working+/


### PR DESCRIPTION
To allow setting `-maxHeap` variable at SpotBugs CLI.

Defaults to 768MB, the same as SpotBugs.